### PR TITLE
Fix the installation of gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 npm-debug.log
-
+package-lock.json
 
 cached-pages/

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "emojione": "^2.2.7",
     "eslint": "^3.15.0",
     "fs-extra": "^2.0.0",
-    "gulp": "gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-eslint": "^3.0.1",
     "isomorphic-fetch": "^2.2.1",
     "sanitize-filename": "^1.6.1",


### PR DESCRIPTION
There is no 4.0 branch in the gulp repo anymore. The master branch now contains the 4.x code.
This installs the 4.x release from the registry.