### PR TITLE
Drop gulp-eslint to run gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,24 +1,9 @@
 const gulp = require('gulp');
 const Promise = require('bluebird');
 const fs = require('fs-extra');
-const eslint = require('gulp-eslint');
 const outputFile = Promise.promisify(fs.outputFile);
 
 const generateEmojiUnicodeVersionMap = require('./tasks/emoji-unicode-version-map');
-
-
-gulp.task('lint-js', () => {
-	return gulp.src(['**/*.js', '!node_modules/**'])
-		.pipe(eslint())
-		// eslint.format() outputs the lint results to the console.
-    .pipe(eslint.format());
-});
-
-
-gulp.task('lint', gulp.series(
-	'lint-js'
-));
-
 
 gulp.task('generate-emoji-unicode-version-map', () => {
 	return outputFile('./emoji-unicode-version-map.json', JSON.stringify(generateEmojiUnicodeVersionMap(), null, '\t'));
@@ -30,6 +15,5 @@ gulp.task('build', gulp.series(
 
 
 gulp.task('default', gulp.series(
-	'lint',
 	'build'
 ));

--- a/package-lock.json
+++ b/package-lock.json
@@ -2408,17 +2408,6 @@
         }
       }
     },
-    "gulp-eslint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-5.0.0.tgz",
-      "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
-      "dev": true,
-      "requires": {
-        "eslint": "^5.0.1",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1"
-      }
-    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -3639,18 +3628,6 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "plugin-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
       }
     },
     "plur": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "prepublish": "npm run lint && npm test && npm run build",
     "build": "gulp build",
-    "lint": "gulp lint",
+    "lint": "eslint \"**/*.js\" --ignore-pattern node_modules",
     "test-unformatted": "node ./tests/tests.js",
     "test": "npm run test-unformatted | tap-spec",
     "compare-maps": "node ./tasks/compare-maps.js",
@@ -30,7 +30,6 @@
     "eslint": "^5.15.3",
     "fs-extra": "^2.0.0",
     "gulp": "^4.0.0",
-    "gulp-eslint": "^5.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.6.3",
     "yargs": "^6.6.0"


### PR DESCRIPTION
The `gulp lint` script does not exit with a failure exit code when eslint fails, making it useless for usage in a scripted usage (as done in the prepublish script for instance).
The `npm run lint` script now uses eslint directly instead of using gulp as a wrapper.
Using eslint directly also allows using its autofixing feature, by running it as `npm run lint -- --fix`.